### PR TITLE
Add Makefile for common development tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.DEFAULT_GOAL := all
+
+# Install project dependencies
+install:
+	npm install
+
+# Build the project
+build:
+	npm run build
+
+# Run unit and e2e tests
+test:
+	npm run test:unit
+	npm run test:e2e
+
+# Lint the codebase
+lint:
+	npm run lint
+
+# Format the codebase
+format:
+	npm run format
+
+# Start the development server
+dev:
+	npm run dev
+
+# Run all common tasks: install, lint, test, and build
+all: install lint test build

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ This template should help get you started developing with Vue 3 in Vite.
 
 TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) to make the TypeScript language service aware of `.vue` types.
 
+## Using the Makefile
+
+This project includes a Makefile to simplify common development tasks. Here are some of the available targets:
+
+*   `make all`: Installs dependencies, lints the code, runs tests, and builds the project. This is the default target.
+*   `make install`: Installs project dependencies using `npm install`.
+*   `make build`: Builds the project using `npm run build`.
+*   `make test`: Runs unit and end-to-end tests.
+*   `make lint`: Lints the codebase using ESLint.
+*   `make format`: Formats the codebase using Prettier.
+*   `make dev`: Starts the development server.
+
+To use these targets, simply run `make <target_name>` in your terminal from the project root. For example, to build the project, you would run `make build`.
+
 ## Customize configuration
 
 See [Vite Configuration Reference](https://vitejs.dev/config/).


### PR DESCRIPTION
This commit introduces a Makefile to streamline common development operations.

The Makefile includes the following targets:
- `all`: (Default) Installs dependencies, lints, tests, and builds the project.
- `install`: Installs project dependencies via npm.
- `build`: Builds the project.
- `test`: Runs both unit and end-to-end tests.
- `lint`: Lints the codebase using ESLint.
- `format`: Formats the codebase using Prettier.
- `dev`: Starts the development server.

Additionally, the README.md has been updated to include instructions on how to use the new Makefile.