### PR TITLE
Fix type-check errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ coverage
 
 test-results/
 playwright-report/
+src/**/*.js

--- a/src/components/TrackComponent.vue
+++ b/src/components/TrackComponent.vue
@@ -71,7 +71,8 @@ const detectionWorker = new AutoCorrelateWorker();
 const time = ref(0);
 const note = ref(0);
 const correlated = ref<any>({});
-const results = ref<{ record: { time: number, detected: number }[], noteEvent: NoteEvent }[]>([]);
+interface AutoCorrelateResult { frequency: number; expectedFrequencyRank: number }
+const results = ref<{ record: { time: number, detected: number, result: AutoCorrelateResult }[], noteEvent: NoteEvent }[]>([]);
 const detection = useRafFn(() => {
   time.value = Number(animation.value?.currentTime ?? 0);
 

--- a/src/model/fingering.ts
+++ b/src/model/fingering.ts
@@ -1,8 +1,9 @@
 import { makeRandomTrackFingering } from './fingering/fingering';
 import { computeComplexity, reportComplexity } from './fingering/penalties';
-import { exhaustiveSearch, iterativeLocalSearch, localSearch, slidingWindowExhaustiveSearch } from './fingering/search';
+import { exhaustiveSearch, iterativeLocalSearch, localSearchTrackFingering, slidingWindowExhaustiveSearch } from './fingering/search';
 import { Instrument } from './instrument';
-import { getUniqueNotes, readMidiFile, transpose, getNoteEventsWithFingeringAlternatives, writeMidiFile } from './midi';
+import { readMidiFile, transpose, writeMidiFile, getNoteEvents } from './midi';
+import { getUniqueNotes, getNoteEventsWithFingeringAlternatives } from './fingering/fingering';
 import fs from 'fs';
 import { Midi } from '@tonejs/midi';
 
@@ -17,7 +18,8 @@ console.log(midi.tracks.map(track => `${track.name} - ${track.instrument.name} -
 
 const track = midi.tracks.filter(track => track.notes.length > 0)[0];
 
-const originalNotes = getUniqueNotes(track);
+const noteEvents = getNoteEvents(track);
+const originalNotes = getUniqueNotes(noteEvents);
 
 const instrument = Instrument.guitar();
 
@@ -28,13 +30,13 @@ transpose(track, transposition);
 // adjust instrument to Acoustic Guitar (nylon)
 track.instrument.number = 24;
 
-const notes = getUniqueNotes(track);
+const notes = getUniqueNotes(noteEvents);
 
 const fingeringAlternatives = instrument.getCompactFingeringAlternativesForNotes(notes);
 
 const totalNumberOfPossibleFingerings = [...fingeringAlternatives.values()].flatMap(a => a).length;
 
-const noteEventsWithStringFretAlternatives = getNoteEventsWithFingeringAlternatives(track, fingeringAlternatives);
+const noteEventsWithStringFretAlternatives = getNoteEventsWithFingeringAlternatives(noteEvents, fingeringAlternatives);
 
 const randomTrackFingering = makeRandomTrackFingering(noteEventsWithStringFretAlternatives);
 
@@ -48,7 +50,7 @@ bestTrackFingering = iterativeLocalSearch(randomTrackFingering, 10, Math.round(l
 
 console.log('complexity', computeComplexity(bestTrackFingering));
 
-bestTrackFingering = localSearch(bestTrackFingering, localSearchSteps, 3);
+bestTrackFingering = localSearchTrackFingering(bestTrackFingering, localSearchSteps, 3);
 
 console.log('complexity', computeComplexity(bestTrackFingering));
 

--- a/src/model/fingering/fingering.ts
+++ b/src/model/fingering/fingering.ts
@@ -1,4 +1,4 @@
-import { exhaustiveSearch, iterativeLocalSearch, localSearch, slidingWindowExhaustiveSearch } from '@/model/fingering/search';
+import { exhaustiveSearch, iterativeLocalSearch, localSearchTrackFingering, slidingWindowExhaustiveSearch } from '@/model/fingering/search';
 import { Instrument } from '@/model/instrument';
 import { Fingering, MidiNote, MidiNoteToFingeringAlternatives, NoteEvent, NoteEventWithFingeringAlternatives } from "@/model/types";
 
@@ -73,7 +73,7 @@ export function createTrackFingering(instrument: Instrument, noteEvents: NoteEve
   let localSearchSteps = Math.round(20000 * (bestTrackFingering.length / 67) * (totalNumberOfPossibleFingerings / 26));
 
   bestTrackFingering = iterativeLocalSearch(randomTrackFingering, 10, Math.round(localSearchSteps / 10), 5);
-  bestTrackFingering = localSearch(bestTrackFingering, localSearchSteps, 3);
+  bestTrackFingering = localSearchTrackFingering(bestTrackFingering, localSearchSteps, 3);
   bestTrackFingering = slidingWindowExhaustiveSearch(bestTrackFingering);
   bestTrackFingering = exhaustiveSearch(bestTrackFingering, 1);
 


### PR DESCRIPTION
## Summary
- fix return types in fingering algorithms
- adjust CLI script to use note events
- extend results type in TrackComponent
- ignore generated JS files

## Testing
- `npm run type-check`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6840823d3818832794ef364f8ba1b849