### PR TITLE
Set noEmit to true for cleaner builds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,6 +85,7 @@
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "noEmit": true,                                     /* Avoid generating JavaScript files during type checking. */
 
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */


### PR DESCRIPTION
## Summary
- avoid generating JS by adding `noEmit: true` to `tsconfig.json`

## Testing
- `npm run build`
- `npm run test:unit` *(fails: ListChangesTracker > Performance > should be independent of list length)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8b47a588327ac17fec692cfdc32