### PR TITLE
Fix base path for GitHub pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,11 @@ npm run test:e2e -- --debug
 ```sh
 make lint
 ```
+
+### Deploy to GitHub Pages
+
+The application is published at <https://isinlor.github.io/guitar/>. The Vite
+configuration sets the `base` option to `/guitar/` so that built assets have the
+correct paths when served from this subfolder. The accompanying GitHub Actions
+workflow runs `make build` to produce the production files under this base
+path.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // The site is hosted at https://isinlor.github.io/guitar/
+  // which means assets must be served from the /guitar/ base path
+  base: '/guitar/',
   plugins: [
     vue(),
   ],


### PR DESCRIPTION
## Summary
- set Vite `base` path for GitHub Pages
- document GitHub Pages deployment

## Testing
- `make checks` *(fails: Missing X server for Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_684125b2879c832790c64ce907cbc041