### PR TITLE
Add 11-string kantele instrument option

### DIFF
--- a/src/components/TrackComponent.vue
+++ b/src/components/TrackComponent.vue
@@ -311,6 +311,26 @@ function stop() {
   border-top: 2px solid #999;
 }
 
+.string-7 {
+  border-top: 2px solid #aaa;
+}
+
+.string-8 {
+  border-top: 2px solid #bbb;
+}
+
+.string-9 {
+  border-top: 2px solid #ccc;
+}
+
+.string-10 {
+  border-top: 2px solid #ddd;
+}
+
+.string-11 {
+  border-top: 2px solid #eee;
+}
+
 .note {
   position: absolute;
   top: 0px;

--- a/src/model/instrument.spec.ts
+++ b/src/model/instrument.spec.ts
@@ -4,6 +4,21 @@ import { Instrument } from './instrument'
 
 describe('Instrument', () => {
 
+  describe('kantele', () => {
+    it('should create an 11-string kantele', () => {
+      const instrument = Instrument.kantele();
+      expect(instrument.strings).toHaveLength(11);
+      expect(instrument.fretsAmount).toBe(0);
+      expect(instrument.baseFrequencies[1]).toBeCloseTo(783.99);
+      expect(instrument.baseFrequencies[11]).toBeCloseTo(293.66);
+    });
+
+    it('should be retrievable via Instrument.get', () => {
+      const instrument = Instrument.get('kantele');
+      expect(instrument.strings).toHaveLength(11);
+    });
+  });
+
   describe('getStringFretAlternatives', () => {
 
     it('should return the string and fret alternatives for a single note', () => {

--- a/src/model/instrument.ts
+++ b/src/model/instrument.ts
@@ -15,6 +15,7 @@ export class Instrument {
     switch (name) {
       case "ukulele": return Instrument.ukulele();
       case "guitar": return Instrument.guitar();
+      case "kantele": return Instrument.kantele();
       default: throw new Error(`No instrument found with name ${name}!`);
     }
   }
@@ -41,6 +42,25 @@ export class Instrument {
         4: 146.83, // D string
         5: 110.00, // A string
         6: 82.41   // E string (6th, thickest)
+      }
+    );
+  }
+
+  public static kantele(): Instrument {
+    return new Instrument(
+      "kantele", 0,
+      {
+        1: 783.99, // G5
+        2: 739.99, // F#5
+        3: 659.26, // E5
+        4: 587.33, // D5
+        5: 554.37, // C#5
+        6: 493.88, // B4
+        7: 440.00, // A4
+        8: 392.00, // G4
+        9: 369.99, // F#4
+        10: 329.63, // E4
+        11: 293.66  // D4
       }
     );
   }

--- a/src/views/FretboardView.vue
+++ b/src/views/FretboardView.vue
@@ -14,10 +14,14 @@ const instruments = {
   guitar: {
     strings: 6,
     frets: 12
+  },
+  kantele: {
+    strings: 11,
+    frets: 0
   }
 }
 
-const selectedInstrument = ref<'ukulele' | 'guitar'>('guitar')
+const selectedInstrument = ref<'ukulele' | 'guitar' | 'kantele'>('guitar')
 const instrument = computed(() => instruments[selectedInstrument.value])
 
 const music = ref<any>([]) // Initialize music ref
@@ -56,6 +60,7 @@ const handleFileUpload = (event: Event) => {
     <select v-model="selectedInstrument">
       <option value="guitar">Guitar</option>
       <option value="ukulele">Ukulele</option>
+      <option value="kantele">11-string Kantele</option>
     </select>
   </label>
   <input type="file" accept=".json,.mid" @change="handleFileUpload" />

--- a/src/views/TunerView.vue
+++ b/src/views/TunerView.vue
@@ -7,10 +7,11 @@ import { centsOffFromNote, noteNumberFromFrequency } from '@/model/midi'
 
 const instruments = {
   ukulele: Instrument.ukulele(),
-  guitar: Instrument.guitar()
+  guitar: Instrument.guitar(),
+  kantele: Instrument.kantele()
 }
 
-const selectedInstrument = ref<'ukulele' | 'guitar'>('guitar')
+const selectedInstrument = ref<'ukulele' | 'guitar' | 'kantele'>('guitar')
 const instrument = computed(() => instruments[selectedInstrument.value])
 
 const worker = new AutoCorrelateWorker()
@@ -134,6 +135,7 @@ const allTuned = computed(() => instrument.value.strings.every((s) => stringStat
     <select v-model="selectedInstrument">
       <option value="guitar">Guitar</option>
       <option value="ukulele">Ukulele</option>
+      <option value="kantele">11-string Kantele</option>
     </select>
   </label>
 


### PR DESCRIPTION
## Summary
- add 11-string kantele instrument with D-major tuning and 0 frets
- allow selecting kantele in tuner and fretboard views
- extend track component styles to support additional string lines

## Testing
- `npx vitest run`
- `npx playwright test` *(fails: missing system dependencies)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc202c128c8327806cf64ca61d7d66