### PR TITLE
Add AGENTS.md with required `make checks` instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions
+
+- Always run `make checks` from the repository root before finalizing changes.
+- If the code is working correctly, these checks should complete successfully.
+
+## Running checks successfully
+
+1. From the repo root, run:
+   ```sh
+   make checks
+   ```
+2. This target runs linting, type-checking, unit tests, and Playwright tests.
+3. If Playwright cannot find a system Chromium, the Makefile will attempt to install one automatically. Ensure the environment allows the install step (it uses `sudo apt-get` and downloads Google Chrome) so Playwright tests can run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-- Always run `make checks` from the repository root before finalizing changes.
+- ALWAYS run `make checks` from the repository root before finalizing changes.
 - If the code is working correctly, these checks should complete successfully.
 
 ## Running checks successfully


### PR DESCRIPTION
### Motivation

- Ensure agents always run `make checks` before finalizing changes.
- Provide clear, reproducible steps for running the repository checks locally.
- Explain Playwright browser handling so end-to-end tests can run when system Chromium is not present.

### Description

- Add `AGENTS.md` containing instructions that agents must run `make checks` from the repo root.
- Document that `make checks` runs `lint`, `type-check`, `vitest`, and `playwright`.
- Note the Makefile behavior to attempt a Playwright browser download and fall back to installing Google Chrome via `apt-get` if no system Chromium is found.

### Testing

- Ran `make checks`, which executed `npm run lint` and `npm run type-check` successfully.
- Ran unit tests with `npx vitest run`, with all unit tests passing (120 tests across the suite).
- Ran Playwright tests via `npx playwright test`, during which the workflow downloaded/installed a browser (fell back to `google-chrome`), and both Playwright tests passed.
- The overall `make checks` target completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a5cd254c8327990b2668f4526784)